### PR TITLE
Adicionar template de issue para tarefas da equipe.

### DIFF
--- a/.github/ISSUE_TEMPLATE/-organiza--o--adicionar-tarefa---co.md
+++ b/.github/ISSUE_TEMPLATE/-organiza--o--adicionar-tarefa---co.md
@@ -1,0 +1,16 @@
+---
+name: "[Organização] Adicionar Tarefa à CO"
+about: Issues para servir de tarefas à organização da SECCOM. Para uso interno.
+title: 'Tarefa: {Qual?}'
+labels: team:task
+assignees: ''
+
+---
+
+Checklist
+---------
+
+- [ ] _Atividade 1__;
+- [ ] _Atividade 2__;
+- [ ] _Atividade 3__;
+- [ ] _Atividade 4__.


### PR DESCRIPTION
A ideia é que assim a equipe possa se organizar utilizando as issues do GitHub, aproveitando inclusive a [página de issues do usuário](https://github.com/issues).

No momento, ao criar uma issue, ficará [assim](https://github.com/seccom-ufsc/manual/blob/df332044ea5efdc8d89a33ad48997af194aa843c/.github/ISSUE_TEMPLATE/-organiza--o--adicionar-tarefa---co.md) (o header no topo são os atributos padrões, não ficam no corpo da issue).